### PR TITLE
Turn release 0.1.4.2 into 0.1.5.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 `wai-middleware-delegate` uses [PVP Versioning][1].
 
+## 0.1.5.0 -- 2024-10-28
+
+*  Upgrade 0.1.4.2 to a minor release
+
 ## 0.1.4.2 -- 2024-10-28
 
 * Export defaultSettings as an alternative to Default#def

--- a/wai-middleware-delegate.cabal
+++ b/wai-middleware-delegate.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               wai-middleware-delegate
-version:            0.1.4.2
+version:            0.1.5.0
 synopsis:           WAI middleware that delegates handling of requests.
 description:
   [WAI](http://hackage.haskell.org/package/wai) middleware that intercepts requests


### PR DESCRIPTION
- it expanded the exported API and should be a new minor release