### PR TITLE
Replace the use of mustache with simple functions

### DIFF
--- a/wai-middleware-delegate.cabal
+++ b/wai-middleware-delegate.cabal
@@ -79,12 +79,12 @@ test-suite integration-test
     , data-default             >=0.7 && <0.9
     , directory                >=1.3 && <1.4
     , filepath                 >=1.4 && <1.6
+    , fmt                      >=0.6.3  && <0.8
     , hspec                    >=2.1
     , hspec-tmp-proc
     , http-client
     , http-client-tls
     , http-types
-    , mustache                 >=2.3 && <2.5
     , network
     , random                   >=1.1
     , resourcet


### PR DESCRIPTION
Simplifies maintenance of this package by removing a dependency that affects the compilation of the tests

At the moment (2025/03), there is a bug on mustache where it internally conflicts with updates to Data.Text in newer versions of GHC; stopping the tests from compiling

A fix has been [provided](https://github.com/JustusAdam/mustache/pull/67), though small, it's neither been approved or released.
